### PR TITLE
Second try: findDeferCb doesn't work with optional, undefined, parameters.  Fixed.

### DIFF
--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -169,7 +169,7 @@ function findDeferCb (l) {
     var ret = null;
     for (var i in l) {
 	var arg = l[i];
-	if (arg.__tame_trace) {
+	if (arg && arg.__tame_trace) {
 	    ret = arg;
 	    break;
 	}


### PR DESCRIPTION
findDeferCb doesn't work with optional, undefined, parameters. Fixed.

Throws: TypeError: Cannot read property '__tame_trace' of undefined
at Object.findDeferCb .../tamejs/lib/runtime.js:172:9)
