### PR TITLE
Cache compiled code.

### DIFF
--- a/lib/tamejs.js
+++ b/lib/tamejs.js
@@ -2,16 +2,44 @@
 "use strict";
 
 var runtime = require ('./runtime').runtime;
+var fs = require('fs');
+var path = require('path');
+var engineVersion = "0.4.3";
+
 exports.runtime = runtime;
 
 //-----------------------------------------------------------------------
 
 function _extension (module, filename) {
-    var Engine = require ('./engine').Engine;
-    var engine = new Engine (filename);
-    engine.readInputSync ();
-    engine.parse ();
-    var out = engine.compile ().formatOutput ();
+    
+    var cachePath = path.join(path.dirname(filename), "." + path.basename(filename) + "." + engineVersion + ".cache");
+ 
+    try{
+        var cacheStats = fs.statSync(cachePath);
+    }catch(e){ cacheStats = null; }
+    
+    var recompile = true;
+    if(cacheStats){
+        var tjsStats = fs.statSync(filename);
+
+        if(cacheStats.mtime >  tjsStats.mtime){ 
+            recompile = false;
+        }
+    }
+    
+    var out = "";
+
+    if(recompile){
+        var Engine = require ('./engine').Engine;
+        var engine = new Engine (filename);
+        engine.readInputSync ();
+        engine.parse ();
+        out = engine.compile ().formatOutput ();
+        fs.writeFile(cachePath, out);
+    }else{
+        out = fs.readFileSync(cachePath, 'utf8');
+    }
+
     module._compile (out, filename);
 };
 
@@ -31,14 +59,14 @@ function register (options) {
 
     if (!options) { options = {}; }
     else if (typeof (options) == 'string' || options instanceof Array) { 
-	options = { extension : options } ;
+    	options = { extension : options } ;
     }
 
     var ext = "tjs";
     if (options.extension) { ext = options.extension; }
     if (!(ext instanceof Array)) { ext = [ ext ]; }
     for (var e in ext) {
-	require.extensions["." + ext[e]] = _extension;
+	    require.extensions["." + ext[e]] = _extension;
     }
 
     if (options.catchExceptions) { runtime.catchExceptions (); }


### PR DESCRIPTION
I added caching to the require extension to avoid redundant recompilation of scripts.  Recompilation isn't terribly slow, but for my purposes, it's too slow.  A hidden compiled file is created in the same directory as the source file, and is used if the mtime on the source file isn't more recent than the cached version.  I append a version number to the cache file name, in case you make breaking changes you can just increment the number, and the next version won't pickup cached versions compiled with older engines.  I put the cached file in the same directory as the source because there is less chance of a file name collision, than if we store them locally in module's tree, and if you need to debug the file, you have a copy right next to your source.  This one might not be for everybody, but I think it's pretty unobtrusive.
