### PR TITLE
Add getCompiledFileSync and refactor _extension

### DIFF
--- a/lib/tamejs.js
+++ b/lib/tamejs.js
@@ -11,7 +11,7 @@ exports.runtime = runtime;
 
 //-----------------------------------------------------------------------
 
-function _extension (module, filename) {
+function getCompiledFileSync(filename){
 
     var recompile = true;
 
@@ -49,6 +49,16 @@ function _extension (module, filename) {
         out = fs.readFileSync(cachePath, 'utf8');
     }
 
+    return(out);
+};
+
+//-----------------------------------------------------------------------
+
+exports.getCompiledFileSync = getCompiledFileSync;
+
+//-----------------------------------------------------------------------
+function _extension (module, filename) {
+    var out = getCompiledFileSync(filename);
     module._compile (out, filename);
 };
 


### PR DESCRIPTION
I've exported and refactored the function that gets the text of the compiled file. It's a helpful interface for anyone wanting to integrate tame into another piece of software; me for instance.
