### PR TITLE
Fixed: blank file as input produces invalid javascript file

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -1995,7 +1995,12 @@ function Program (shbang, statements) {
 	out.addLine ("var __tame_defer_cb = null;");
 	var body = this._body.compile (eng);
 	out.addOutput (body);
-	out.addLine (body.fnName() + " (" + out.endFn() + ");");
+        if(body.fnName() === undefined){
+            out.addLine ("(function(){})(" + out.endFn() + ");");
+        }else{
+            out.addLine (body.fnName() + " (" + out.endFn() + ");");
+        }
+
 	return out;
     };
 


### PR DESCRIPTION
Running tamejs on an empty file, produced an invalid javascript file. Notice the call to "undefined" as a function on the last line. Now it calls an anonymous function.

Output Was:

var tame = require('tamejs').runtime;  
var __tame_defer_cb = null;
undefined (tame.end);

Output Is:

var tame = require('tamejs').runtime;  
var __tame_defer_cb = null;
(function(){})(tame.end);
