### PR TITLE
A fix for tamejs to coexist with other code that modifies Array.prototype

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -51,6 +51,7 @@ function Node (startLine) {
     this.compress = function () {
 	var v = this.getChildren ();
 	for (var i in v) {
+            if (! v.hasOwnProperty(i)) { continue; }
 	    v[i].compress ();
 	}
     };
@@ -66,6 +67,7 @@ function Node (startLine) {
 	var v = this.getChildren ();
 	var ret = 0;
 	for (i in v) {
+            if (! v.hasOwnProperty(i)) { continue; }
 	    if (v[i].hasAwaitStatement ()) {
 		ret = 1;
 		break;
@@ -85,6 +87,7 @@ function Node (startLine) {
 	this._thisses = [];
 	var v = this.getChildren ();
 	for (var i in v) {
+            if (! v.hasOwnProperty(i)) { continue; }
 	    var c = v[i];
 	    if (c.toThis ()) { this._thisses.push (c); }
 	    else if (!c.toFunction ()) { 
@@ -104,6 +107,7 @@ function Node (startLine) {
 	this._declarations = [];
 	var v = this.getChildren ();
 	for (var i in v) {
+	    if (! v.hasOwnProperty(i)) { continue; }
 	    d = v[i].getDeclarations (eng);
 	    this._declarations = this._declarations.concat (d);
 	}
@@ -269,6 +273,8 @@ function DeferExpr (startLine, slotList) {
 	var simple = true;
 
 	for (var i in this._slotList) {
+
+	  if (! this._slotList.hasOwnProperty(i)) { continue; }
 	    var o = this._slotList[i];
 	    var slot = new Slot (o, eng, this._varRxx, i);
 	    if (!slot.simple ()) { 
@@ -294,6 +300,7 @@ function DeferExpr (startLine, slotList) {
 	    }
 	    
 	    for (var i in outputs) {
+		if (! outputs.hasOwnProperty(i)) { continue; }
 		ret.addLine (outputs[i]);
 	    }
 	    
@@ -522,6 +529,7 @@ function Expr (atoms) {
 
     that.pushAtomsToArray = function (out) {
 	for (var i in this._atoms) {
+	    if (! this._atoms.hasOwnProperty(i)) { continue; }
 	    out.push (this._atoms[i]);
 	}
     };
@@ -547,6 +555,7 @@ function Expr (atoms) {
 	}
 
 	for (var i in this._atoms) {
+	    if (! this._atoms.hasOwnProperty(i)) { continue; }
 	    var atom = this._atoms[i];
 	    var atomc = atom.compile (eng);
 	    ret.addOutput (atomc);
@@ -568,6 +577,7 @@ function Expr (atoms) {
     that.passThrough = function (eng) { 
 	var out = eng.newOutput ();
 	for (var i in this._atoms) {
+            if (! this._atoms.hasOwnProperty(i)) { continue; }
 	    var a = this._atoms[i].passThrough (eng);
 	    out.addOutput (a);
 	}
@@ -600,6 +610,7 @@ function Expr (atoms) {
     that.inline = function (eng, inTame) {
 	var out = eng.newOutput ();
 	for (var i in this._atoms) {
+            if (! this._atoms.hasOwnProperty(i)) { continue; }
 	    var atom = this._atoms[i];
 	    var atomc = atom.passThrough (eng, inTame);
 	    out.addOutput (atomc);
@@ -708,6 +719,7 @@ function Block (startLine, body, toplev) {
     that.passThrough = function (eng) {
 	var ret = eng.newOutput ();
 	for (var i in this._body) {
+	    if (! this._body.hasOwnProperty(i)) { continue; }
 	    var s = this._body[i].passThrough (eng);
 	    ret.addOutput (s);
 	}
@@ -1032,6 +1044,7 @@ function SwitchStatement (startLine, expr, cases) {
 	ret.addLine ("switch (" + this._expr.inline (eng, false) + ") {");
 	ret.indent ();
 	for (var i in this._cases) {
+	    if (! this._cases.hasOwnProperty(i)) { continue; }
 	    var c = this._cases[i].passThrough (eng);
 	    ret.addOutput (c);
 	}
@@ -1072,6 +1085,7 @@ function SwitchStatement (startLine, expr, cases) {
 
 	var calls = [];
 	for (i in this._cases) {
+            if (! this._cases.hasOwnProperty(i)) { continue; }
 	    var c = this._cases[i].getBody ().compile (eng);
 	    ret.addOutput (c);
 	    calls.push (c.fnNameRequired ());
@@ -1081,6 +1095,7 @@ function SwitchStatement (startLine, expr, cases) {
 	ret.addLine ("var " + l + " = [" + calls.join (", ") + "];");
 	var n_open = 0;
 	for (i in this._cases) {
+            if (! this._cases.hasOwnProperty(i)) { continue; }
 	    var c = this._cases[i];
 	    var v = c.getValue ();
 	    if (v) {
@@ -1308,6 +1323,7 @@ function FunctionDeclaration (startLine, name, params, body) {
     that._has_autocb = false;
 
     for (var i in params) {
+        if (! params.hasOwnProperty(i)) { continue; }
 	if (params[i] == autocb_name) {
 	    that._has_autocb = true;
 	}
@@ -1366,6 +1382,7 @@ function FunctionDeclaration (startLine, name, params, body) {
 	// ThisExpr's need to know if their parent is tamed or not.
 	var thisses = this.getThisses ();
 	for (var i in thisses) {
+	    if (! thisses.hasOwnProperty(i)) { continue; }
 	    thisses[i].setParentFunc (this);
 	}
 
@@ -1438,6 +1455,7 @@ function AwaitStatement (startLine, body) {
 
 	var decls = this._body.getDeclarations (eng);
 	for (var i in decls) {
+	    if (! decls.hasOwnProperty(i)) { continue; }
 	    var decl = decls[i];
 	    ret.addLine (decl);
 	}

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -116,6 +116,7 @@ function Output (eng, fnName, startLine) {
     this.addLines = function (v, no) {
 	if (!no) { no = -1; }
 	for (var i in v) {
+	    if (! v.hasOwnProperty(i)) { continue; }
 	    this.addLine (v[i], no);
 	    if (no >= 0) { no++; }
 	}
@@ -136,6 +137,7 @@ function Output (eng, fnName, startLine) {
 
     this.addOutput = function (o) {
 	for (var i in o._lines) {
+	    if (! o._lines.hasOwnProperty(i)) { continue; }
 	    var line = o._lines[i];
 	    line.incIndent (this._indent);
 	    this.addLineObj (line);
@@ -228,6 +230,7 @@ function Output (eng, fnName, startLine) {
 	// prune out any nulls (caused by code inlining)
 	var pruned = [];
 	for (var i in calls) {
+	    if (! calls.hasOwnProperty(i)) { continue; }
 	    if (calls[i]) {
 		pruned.push (calls[i]);
 	    }
@@ -263,6 +266,7 @@ function Output (eng, fnName, startLine) {
     this.formatOutputLines = function () {
 	var out = [];
 	for (var i in this._lines) {
+	    if (! this._lines.hasOwnProperty(i)) { continue; }
 	    var l = this._lines[i];
 	    var line = this.outputIndent (l.indent ()) + l.text ();
 	    out.push (line);

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -47,7 +47,8 @@ function end () {}
 
 function restArr (from, offset) {
     var to = [];
-    for (var i in from) { 
+    for (var i in from) {
+        if (! from.hasOwnProperty(i)) { continue; } 
 	var j = parseInt (i);
 	to[j] = from[offset + j]; 
     }
@@ -67,6 +68,7 @@ function makeDeferReturn (x, defer_args, id) {
 	ret.__tame_trace = {};
 	var keys = [ "parent_cb", "file", "line", "func_name" ];
 	for (var k in keys) {
+	    if (! keys.hasOwnProperty(k)) { continue; }
 	    var key = keys[k];
 	    ret.__tame_trace[key] = defer_args[key];
 	}
@@ -168,6 +170,7 @@ function getActiveCb () { return _active_cb; }
 function findDeferCb (l) {
     var ret = null;
     for (var i in l) {
+        if (! l.hasOwnProperty(i)) { continue; }
 	var arg = l[i];
 	if (arg && arg.__tame_trace) {
 	    ret = arg;

--- a/lib/tamejs.js
+++ b/lib/tamejs.js
@@ -86,6 +86,7 @@ function register (options) {
     if (options.disableCache) { useCache = false; }
     if (!(ext instanceof Array)) { ext = [ ext ]; }
     for (var e in ext) {
+        if (! ext.hasOwnProperty(e)) { continue; }
 	require.extensions["." + ext[e]] = _extension;
     }
 


### PR DESCRIPTION
Using the `for...in` construction to iterate over array objects in JavaScript results in unexpected behavior if Array.prototype is ever changed.

For example:

``` javascript
Array.prototype.unique = function() { /* code */ }
var a = [1,2,3];

for (var i in a) {
  console.log(i);
}
```

yields

> 1
> 2
> 3
> unique

This is problematic when code assumes that all the values returned by a `for...in` construction will be of a single type because, well, that's what the array has in it.

Fortunately, there's a simple, if inelegant, solution: add the line

``` javascript
if (! a.hasOwnProperty(i)) { continue; }
```

to the beginning of each `for...in` block, with the appropriate variable substitutions.

This pull request makes that change.
