### PR TITLE
update engine number, update NEWS.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 News And Changelog
 ==================
 
+v0.4.10
+------
+* Add support for the arguments pseudo array in tamed functions
+
 v0.4.9
 ------
 * Fix bug in !== lexing

--- a/lib/tamejs.js
+++ b/lib/tamejs.js
@@ -4,7 +4,7 @@
 var runtime = require ('./runtime').runtime;
 var fs = require('fs');
 var path = require('path');
-var engineVersion = "0.4.9";
+var engineVersion = "0.4.10";
 var useCache = true;
 
 exports.runtime = runtime;


### PR DESCRIPTION
Hi Max,

I just realized I never updated the engine number, or the news when I added support for the arguments array. Also, npm seems to think it's on version 0.4.11, but the package.json shows 0.4.10. I noticed an extra tag from a year ago that might be confusing it. Can you publish the new version on npm? I imagine you're pretty busy, I read about Keybase in Wired, sounds pretty cool. Amusingly I just setup GPG a couple days ago. Thanks and best of luck.

Kendrick
